### PR TITLE
Bug/fix anatree update

### DIFF
--- a/game_gen/src/anagrams.cpp
+++ b/game_gen/src/anagrams.cpp
@@ -92,7 +92,7 @@ int main(int argc, char* argv[])
 
   std::cout << "Anatree:" << std::endl
             << "| # Words:           " << used_words << " words (" << used_chars << " characters)." << std::endl
-            << "| # Nodes:           " << a.size() << std::endl
+            << "| # Nodes:           " << a.tree_size() << std::endl
             << "| # Keys:            " << keys.size() << std::endl
             << "| Time:              " << std::endl
             << "| | Insertion:       " << anatree_insert__time << " ns" << std::endl

--- a/game_gen/src/anagrams.cpp
+++ b/game_gen/src/anagrams.cpp
@@ -122,7 +122,7 @@ int main(int argc, char* argv[])
     std::ofstream out_file(ss.str());
 
     const time_point anagrams__start_time = get_timestamp();
-    std::unordered_set<std::string> game = a.anagrams_of(k);
+    std::unordered_set<std::string> game = a.subanagrams_of(k);
     const time_point anagrams__end_time = get_timestamp();
     anagrams__time += duration_of(anagrams__start_time, anagrams__end_time);
 

--- a/game_gen/src/anagrams.cpp
+++ b/game_gen/src/anagrams.cpp
@@ -108,8 +108,7 @@ int main(int argc, char* argv[])
   size_t anagrams__time = 0;
 
   for (std::string k : keys) {
-    // Ignore keys that would lead to a game with the longest word not being of
-    // MAX length
+    // Ignore keys that would lead to a game with the longest word not being of MAX length
     if (word_size(k) < MAX_LENGTH) {
       skipped__short_keys += 1;
       continue;


### PR DESCRIPTION
Commit fbae800 forwarded the Anatree version to v1.0+ (where it was at a v0.x version previously). This seems to have run into breaking changes as the meaning of `anagrams_of` has changed (with the previous version delegated to `subanagrams_of`).