### PR TITLE
fix: remove skip directly into game feature

### DIFF
--- a/game/src/app.tsx
+++ b/game/src/app.tsx
@@ -16,7 +16,6 @@ import './app.scss';
 const LS_KEYS = {
   DarkMode: "DarkMode",
   Mode: "Mode",
-  HasPlayed: "HasPlayed",
   Language: "Language",
   Sound: "Sound",
 };
@@ -68,11 +67,7 @@ const App = () => {
     }
   );
 
-  const [inGame, setInGame] = useState<boolean>(() => {
-    // Go directly into a game, if settings have already been set
-    const ls_res = localStorage.getItem(LS_KEYS.HasPlayed);
-    return ls_res !== null;
-  });
+  const [inGame, setInGame] = useState<boolean>(false);
 
   // ------------------------------------------------------------------------
   // SAVE USER SETTINGS
@@ -84,10 +79,6 @@ const App = () => {
   }
 
   useEffect(updateLocalStorage, [darkMode, sound, language, mode]);
-
-  useEffect(() => {
-    if (inGame) { localStorage.setItem(LS_KEYS.HasPlayed, "true"); }
-  }, [inGame]);
 
   // ------------------------------------------------------------------------
   // Sound


### PR DESCRIPTION
## Summary
Fixes #142

## Problem
The app was remembering previous settings via the \HasPlayed\ localStorage key and automatically skipping the menu to start a new game on return visits. As noted in the issue, this behavior was confusing and annoying.

## Solution
- Removed the \HasPlayed\ key from \LS_KEYS\
- Changed \inGame\ state initialization from localStorage check to simply \alse\
- Removed the \useEffect\ that stored \HasPlayed\ in localStorage

## Result
The app now always starts on the menu screen, allowing users to select their preferred language and mode before starting a new game. User preferences for dark mode, sound, language, and mode are still remembered.