### PR TITLE
feat: add dashed border to hint letters for colorblind accessibility

### DIFF
--- a/game/src/game/word.scss
+++ b/game/src/game/word.scss
@@ -49,6 +49,8 @@
 
         &.Hint {
             background-color: $light-hint;
+            /* Accessibility: dashed border for colorblind/monochrome differentiation */
+            border-bottom: 3px dashed $light-text-color;
         }
     }
 
@@ -72,6 +74,8 @@
 
         &.Hint {
             background-color: $light-hint;
+            /* Accessibility: dashed border for colorblind/monochrome differentiation */
+            border-bottom: 3px dashed $light-text-color;
         }
     }
 }
@@ -82,6 +86,8 @@
 
         &.Hint {
             background-color: $dark-hint;
+            /* Accessibility: dashed border for colorblind/monochrome differentiation */
+            border-bottom: 3px dashed $dark-text-color;
         }
     }
 
@@ -105,6 +111,8 @@
 
         &.Hint {
             background-color: $dark-hint;
+            /* Accessibility: dashed border for colorblind/monochrome differentiation */
+            border-bottom: 3px dashed $dark-text-color;
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR adds visual differentiation for hint letters (yellow) beyond color alone, making the game accessible to colorblind and monochrome users.

## Changes
- Added a dashed bottom border (\order-bottom: 3px dashed\) to all \.Hint\ classes in \game/src/game/word.scss\
- Applied consistently across all 4 states:
  - Light mode, non-guessed hint letters
  - Light mode, guessed hint letters
  - Dark mode, non-guessed hint letters
  - Dark mode, guessed hint letters
- Uses the text color for the border to ensure visibility in all themes

## Why This Approach
According to WCAG accessibility guidelines, information should not be conveyed through color alone. By adding a dashed border pattern to hint letters, users can distinguish them from correctly guessed letters (green/solid) even without color perception.

The dashed border style:
- Is visually distinct from solid borders
- Doesn't interfere with the existing design
- Works well in both light and dark modes
- Maintains the game's aesthetic while improving accessibility

## Testing
- Verified the SCSS compiles successfully (\
pm run build\)
- Changes applied to all theme variations

Fixes #141